### PR TITLE
Rework tag syntax, refactorize

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,5 +20,11 @@ jobs:
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest
 
+            - name: Validate coding standards in source
+              run: ./vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/
+
+            - name: Validate coding standards in test suite
+              run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony tests/
+
             - name: Run test suite
               run: composer run-script test

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -1,0 +1,27 @@
+name: Coding Standards
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Validate coding standards in source
+        run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/
+
+      - name: Validate coding standards in test suite
+        run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Unit Tests
 
 on:
     push:
@@ -14,17 +14,8 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Validate composer.json and composer.lock
-              run: composer validate
-
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest
-
-            - name: Validate coding standards in source
-              run: ./vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/
-
-            - name: Validate coding standards in test suite
-              run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony tests/
 
             - name: Run test suite
               run: composer run-script test

--- a/README.md
+++ b/README.md
@@ -420,10 +420,14 @@ files:
 About
 -----
 
+### Development Requirements
+
+* [Composer](https://getcomposer.org/) usable as `composer` (like in [global install](https://getcomposer.org/doc/00-intro.md#globally)).
+
 ### Compile Phar
 
 ```shell
-php -d phar.readonly=Off compile-phar.php;
+composer run compile;
 ./exercise-cleaner.phar --version;
 ```
 
@@ -431,9 +435,7 @@ Note: When a release is created, an asset is automatically compiled and attached
 
 ### Run Unit Tests
 
-Note: A `composer install --dev` (or alike) must have been previously executed.
-
-`./vendor/bin/phpunit --colors tests;`
+`composer run test;`
 
 Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, tests are automatically run (see [*PHP Composer* workflow](.github/workflows/php.yml))
 
@@ -450,7 +452,7 @@ done;
 
 Treat examples after compiling and with verbosity:
 ```shell
-php -d phar.readonly=0 compile-phar.php;
+composer run compile;
 ./exercise-cleaner.phar --version;
 rm -f examples/*.step*.*; # Clean previous runs
 for step in 1 1.1 1.2 2 3; do
@@ -461,15 +463,14 @@ done;
 
 Treat shell example and execute the result:
 ```shell
+composer run compile;
 for step in 1 1.1 1.2 2 3; do
-    echo "\nSTEP $step EXERCISE";
-    php src/Application.php $step examples/example.sh;
-    zsh examples/example.sh;
-    git checkout -- examples/example.sh;
-    echo "\nSTEP $step SOLUTION";
-    php src/Application.php --solution $step examples/example.sh;
-    zsh examples/example.sh;
-    git checkout -- examples/example.sh;
+    for state in exercise solution; do
+        echo "\nStep $step $state";
+        ./exercise-cleaner.phar --$state $step examples/example.sh;
+        zsh examples/example.sh;
+        git checkout -- examples/example.sh;
+    done;
 done;
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ The command get paths as arguments; for each given folder, the script will first
 
 A tag doesn't care if is embed in a comment or something else. When matching, the whole line containing the tag becomes the tag. For examples comment doesn't exist in JSON, there is some tricks to not trigger syntax errors but with a limitation for last line without ending comma.
 
+Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [<state>] [<action>] [UNTIL <step_number> [THEN <action>]]`
+
+* `<boundary>` defines if it's an opening or closing tag:
+  - `START`
+  - `STOP`
+* `<step_number>`: float
+* `<state>` defines what to do when the wanted tag equals the tag's step number:
+  - `SOLUTION` (default)
+  - `WORKSHEET` (or deprecated `INTRO)
+  - `PLACEHOLDER`
+* `<action>`:
+  - `KEEP` (`SOLUTION` and `WORKSHEET`'s default)
+  - `COMMENT`
+  - `REMOVE` (`PLACEHOLDER`'s default)`
+
 #### Simple Tag
 
 - `TRAINING EXERCISE START STEP <step_number>`
@@ -55,6 +70,49 @@ When `<step_number>` is **equal to** the wanted step number:
 * **keep** inside content into **solution**.
 
 When `<step_number>` is **smaller than** the wanted step number, **keep** inside content.
+
+The following is equivalent:
+
+- `TRAINING EXERCISE START STEP <step_number> SOLUTION`
+- `TRAINING EXERCISE STOP STEP <step_number>`
+
+#### State Tag
+
+- `TRAINING EXERCISE START STEP <step_number> <state>`
+- `TRAINING EXERCISE STOP STEP <step_number>`
+
+The `<state>` defines what will done when `<step_number>` is equal to or smaller than the wanted step number.
+
+- `TRAINING EXERCISE START STEP <step_number> SOLUTION`
+- `TRAINING EXERCISE STOP STEP <step_number>`
+
+When `<step_number>` is **greater than** the wanted step number, **remove** inside content.
+
+When `<step_number>` is **equal to** the wanted step number:
+* **remove** inside content from **exercise**;
+* **keep** inside content into **solution**.
+
+When `<step_number>` is **smaller than** the wanted step number, **keep** inside content.
+
+- `TRAINING EXERCISE START STEP <step_number> WORKSHEET`
+- `TRAINING EXERCISE STOP STEP <step_number>`
+
+When `<step_number>` is **greater than** the wanted step number, **remove** inside content.
+
+When `<step_number>` is **equal to** the wanted step number, keep in both **exercise and solution**.
+
+When `<step_number>` is **smaller than** the wanted step number, **keep** inside content.
+
+- `TRAINING EXERCISE START STEP <step_number> PLACEHOLDER`
+- `TRAINING EXERCISE STOP STEP <step_number>`
+
+When `<step_number>` is **greater than** the wanted step number, **remove** inside content.
+
+When `<step_number>` is **equal to** the wanted step number:
+* **keep** inside content into **exercise**;
+* **remove** inside content from **solution**.
+
+When `<step_number>` is **smaller than** the wanted step number, **remove** inside content.
 
 #### Single Afterward Action Tag
 
@@ -70,9 +128,14 @@ When `<step_number>` is **equal to** the wanted step number:
 When `<step_number>` is **smaller than** the wanted step number, **execute `<action>`** on inside content.
 
 Available actions:
-* `KEEP` (default)
+* `KEEP` (`SOLUTION` and `WORKSHEET` states' default)
 * `COMMENT`
-* `REMOVE`
+* `REMOVE` (`PLACEHOLDER` state's default)`
+
+The following is equivalent:
+
+- `TRAINING EXERCISE START STEP <step_number> SOLUTION  <action>`
+- `TRAINING EXERCISE STOP STEP <step_number>`
 
 #### Threshold Conditioned Afterward Action Tag
 
@@ -91,7 +154,11 @@ When `<step_number>` is **smaller than** the wanted step number, **execute** one
 
 `<threshold_step_number>` must be greater than `<step_number>`.
 
-#### Intro Keyword
+#### State Tags
+
+The `<state>` part
+
+#### Intro Keyword (deprecated)
 
 Previous tags can contain keyword `INTRO` anywhere after their step number.
 
@@ -99,13 +166,33 @@ Previous tags can contain keyword `INTRO` anywhere after their step number.
 
 With `INTRO`, when `<step_number>` is **equal to** the wanted step number, **keep** inside content in both **exercise and solution**.
 
-#### Placeholder Tag
+#### One-Line Placeholder Tag
 
 - `TRAINING EXERCISE STEP PLACEHOLDER`
 
 When `<step_number>` is **equal to** the wanted step number:
 * **keep** line containing this tag into **exercise** with this tag removed
 * **remove** line containing this tag from **solution
+
+The two following examples are equivalent:
+
+```php
+<?php
+// TRAINING EXERCISE START STEP 1
+// TRAINING EXERCISE STEP PLACEHOLDER TODO: Output the solution
+echo 'Solution';
+// TRAINING EXERCISE START STOP 1
+```
+
+```php
+<?php
+// TRAINING EXERCISE START STEP 1 PLACEHOLDER
+// TODO: Output the solution
+// TRAINING EXERCISE START STOP 1
+// TRAINING EXERCISE START STEP 1
+ echo 'Solution';
+// TRAINING EXERCISE START STOP 1
+```
 
 #### Examples
 
@@ -370,9 +457,6 @@ done;
 ### TODO
 
 * Version string as step numbers
-* Find a better mechanism and wording for `INTRO` and `PLACEHOLDER` (more understandable, more consistent)
-* Handle just `TRAINING EXERCISE START STEP <step_number> <action_b> UNTIL <threshold_step_number>` (with default/implicit `THEN REMOVE`)
-* Handle just `TRAINING EXERCISE START STEP <step_number> UNTIL <threshold_step_number>` (with default/implicit `KEEP UNTIL <n> THEN REMOVE`)
 * More unit tests; smaller unit tests
 * Test with / Update for eZ Platform v3
 * How to easily distribute the .phar?

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The command get a step as an argument and will remove content inside tags having
 
 The command get paths as arguments; for each given folder, if there is no dedicated extension, the script will first search recursively for files containing `TRAINING EXERCISE` (case sensitive), the core part of a tag.
 
-A tag doesn't care if is embed in a comment or something else. When matching, the whole line containing the tag becomes the tag. For examples comment doesn't exist in JSON, there is some tricks to not trigger syntax errors but with a limitation for last line without ending comma.
+A tag doesn't care if is embed in a comment or something else. When matching, the whole line containing the tag becomes the tag. For example, comment doesn't exist in JSON but there is some tricks to not trigger syntax errors but with a limitation for last line without ending comma. The rest of the line can be used for internal notes.
 
 Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [<state>] [<action>] [UNTIL <step_number> [THEN <action>]]`
 

--- a/README.md
+++ b/README.md
@@ -431,13 +431,13 @@ composer run compile;
 ./exercise-cleaner.phar --version;
 ```
 
-Note: When a release is created, an asset is automatically compiled and attached to it (see [*Release Asset* workflow](.github/workflows/release.yml))
+Note: When creating a release, an asset is automatically compiled and attached to it (see [*Release Asset* workflow](.github/workflows/release.yml))
 
 ### Run Unit Tests
 
 `composer run test;`
 
-Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, tests are automatically run (see [*PHP Composer* workflow](.github/workflows/php.yml))
+Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, tests are automatically run (see [*PHP Composer* workflow](.github/workflows/tests.yml))
 
 ### Run Examples
 
@@ -474,11 +474,13 @@ for step in 1 1.1 1.2 2 3; do
 done;
 ```
 
-### Code Style
+### Conform to Standards
 
 Last [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)' rules.
 
-Using [PHP Coding Standards Fixer](https://cs.symfony.com/): `vendor/bin/php-cs-fixer fix --rules=@Symfony src/;` — Note: A `composer install --dev` (or alike) must have been previously executed.
+Conform code (using [PHP Coding Standards Fixer](https://cs.symfony.com/)): `composer run conform;`
+
+Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, conformity tests are automatically run (see [*PHP Composer* workflow](.github/workflows/standards.yml))
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The tags include a step number as an integer or a float.
 
 The command get a step as an argument and will remove content inside tags having a greater one. When it's equal or smaller, see details in below subsections.
 
-The command get paths as arguments; for each given folder, the script will first search recursively for files containing `TRAINING EXERCISE START STEP`, the core part of a starting tag.
+The command get paths as arguments; for each given folder, if there is no dedicated extension, the script will first search recursively for files containing `TRAINING EXERCISE` (case sensitive), the core part of a starting tag.
 
 A tag doesn't care if is embed in a comment or something else. When matching, the whole line containing the tag becomes the tag. For examples comment doesn't exist in JSON, there is some tricks to not trigger syntax errors but with a limitation for last line without ending comma.
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,13 @@ With `INTRO`, when `<step_number>` is **equal to** the wanted step number, **kee
 
 - `TRAINING EXERCISE STEP PLACEHOLDER`
 
+When `<step_number>` is **greater than** the wanted step number, **remove** line containing this tag from **solution**.
+
 When `<step_number>` is **equal to** the wanted step number:
-* **keep** line containing this tag into **exercise** with this tag removed
-* **remove** line containing this tag from **solution
+* **keep** line containing this tag into **exercise** with this tag removed;
+* **remove** line containing this tag from **solution**.
+
+When `<step_number>` is **smaller than** the wanted step number, **remove** line containing this tag from **solution**.
 
 The two following examples are equivalent:
 
@@ -255,8 +259,16 @@ protected function configure()
         // TRAINING EXERCISE START STEP 1 COMMENT
         ->setHelp('Step 1 feature');
         // TRAINING EXERCISE STOP STEP 1
+        // TRAINING EXERCISE START STEP 2 PLACEHOLDER
+        /* TODO:
+            - Add argument(s)
+            - Add option(s)
+            - Update help
+        */
+        // TRAINING EXERCISE STOP STEP 2
         // TRAINING EXERCISE START STEP 2
-        // TRAINING EXERCISE STEP PLACEHOLDER TODO: Update the description
+        ->addArgument('argument', InputArgument::OPTIONAL, 'An optional argument')
+        ->addOption('option', 'o', InputOption::VALUE_OPTIONAL, 'An option with an optional value')
         ->setHelp("Step 1 feature\nStep 2 feature");
         // TRAINING EXERCISE STOP STEP 2
     // TRAINING EXERCISE STOP STEP 1
@@ -288,16 +300,23 @@ protected function configure()
     $this
         ->setDescription('Just an example')
         // ->setHelp('Step 1 feature');
-        // TODO: Update the description
+        /* TODO:
+            - Add argument(s)
+            - Add option(s)
+            - Update help
+        */
 }
 ```
 Step 2's solution (and nex steps' worksheets and solutions):
 ```php
+<?php
 protected function configure()
 {
     $this
         ->setDescription('Just an example')
         // ->setHelp('Step 1 feature');
+        ->addArgument('argument', InputArgument::OPTIONAL, 'An optional argument')
+        ->addOption('option', 'o', InputOption::VALUE_OPTIONAL, 'An option with an optional value')
         ->setHelp("Step 1 feature\nStep 2 feature");
 }
 ```

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Step 2's solution:
 }
 ```
 
-#### PHP Examples w/ Nested Tags & Action Tag
+#### PHP Examples with Nested Tags and Action Tag
 
 Tagged Reference:
 ```php
@@ -274,7 +274,7 @@ protected function configure()
     // TRAINING EXERCISE STOP STEP 1
 }
 ```
-TODO: Update the following results
+
 Step 1's worksheet:
 ```php
 protected function configure()

--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ When `<step_number>` is **smaller than** the wanted step number, **execute** one
 
 `<threshold_step_number>` must be greater than `<step_number>`.
 
-#### State Tags
-
-The `<state>` part
-
 #### Intro Keyword (deprecated)
 
 Previous tags can contain keyword `INTRO` anywhere after their step number.
@@ -416,6 +412,7 @@ files:
 ./exercise-cleaner.phar --config exercise-cleaner.yml 2 examples/;
 ./exercise-cleaner.phar --config exercise-cleaner.yml 2 examples/ --solution;
 ```
+
 
 About
 -----

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [<state>] [<action>] [U
 * `<step_number>`: float
 * `<state>` defines what to do when the wanted tag equals the tag's step number:
   - `SOLUTION` (default)
-  - `WORKSHEET` (or deprecated `INTRO)
+  - `WORKSHEET` (or deprecated `INTRO`)
   - `PLACEHOLDER`
 * `<action>`:
   - `KEEP` (`SOLUTION` and `WORKSHEET`'s default)
   - `COMMENT`
-  - `REMOVE` (`PLACEHOLDER`'s default)`
+  - `REMOVE` (`PLACEHOLDER`'s default)
 
 #### Simple Tag
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ protected function configure()
     $this
         ->setDescription('Just an example')
         // TRAINING EXERCISE START STEP 1 COMMENT
-        ->setHelp('Step 1 feature');
+        ->setHelp('Step 1 feature')
         // TRAINING EXERCISE STOP STEP 1
         // TRAINING EXERCISE START STEP 2 PLACEHOLDER
         /* TODO:
@@ -265,8 +265,9 @@ protected function configure()
         // TRAINING EXERCISE START STEP 2
         ->addArgument('argument', InputArgument::OPTIONAL, 'An optional argument')
         ->addOption('option', 'o', InputOption::VALUE_OPTIONAL, 'An option with an optional value')
-        ->setHelp("Step 1 feature\nStep 2 feature");
+        ->setHelp("Step 1 feature\nStep 2 feature")
         // TRAINING EXERCISE STOP STEP 2
+    ;
     // TRAINING EXERCISE STOP STEP 1
 }
 ```
@@ -285,7 +286,8 @@ protected function configure()
 {
     $this
         ->setDescription('Just an example')
-        ->setHelp('Step 1 feature');
+        ->setHelp('Step 1 feature')
+    ;
 }
 ```
 
@@ -295,25 +297,26 @@ protected function configure()
 {
     $this
         ->setDescription('Just an example')
-        // ->setHelp('Step 1 feature');
+        // ->setHelp('Step 1 feature')
         /* TODO:
             - Add argument(s)
             - Add option(s)
             - Update help
         */
+    ;
 }
 ```
-Step 2's solution (and nex steps' worksheets and solutions):
+Step 2's solution (and next steps' worksheets and solutions):
 ```php
-<?php
 protected function configure()
 {
     $this
         ->setDescription('Just an example')
-        // ->setHelp('Step 1 feature');
+        // ->setHelp('Step 1 feature')
         ->addArgument('argument', InputArgument::OPTIONAL, 'An optional argument')
         ->addOption('option', 'o', InputOption::VALUE_OPTIONAL, 'An option with an optional value')
-        ->setHelp("Step 1 feature\nStep 2 feature");
+        ->setHelp("Step 1 feature\nStep 2 feature")
+    ;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [<state>] [<action>] [U
   - `STOP`
 * `<step_number>`: float
 * `<state>` defines what to do when the wanted tag equals the tag's step number:
-  - `SOLUTION` (default)
-  - `WORKSHEET` (or deprecated `INTRO`)
-  - `PLACEHOLDER`
+  - `SOLUTION` (default) means succinctly that enclosed content is present only in solution
+  - `WORKSHEET` (or deprecated `INTRO`) means succinctly that enclosed content is present in both exercise and solution
+  - `PLACEHOLDER` means succinctly that enclosed content is present only in exercise
 * `<action>`:
   - `KEEP` (`SOLUTION` and `WORKSHEET`'s default)
   - `COMMENT`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Exercise Cleaner
   - [Tags](#tags)
   - [Command](#command)
   - [Config File](#config-file)
-* [About](#about)
+* [Development](#development)
   - [Compile Phar](#compile-phar)
   - [Run Tests](#run-tests)
+  - [Conform to Standards](#conform-to-standards)
   - [Run Examples](#run-examples)
   - [To Do](#todo)  
 
@@ -417,8 +418,8 @@ files:
 ```
 
 
-About
------
+Development
+-----------
 
 ### Development Requirements
 
@@ -438,6 +439,14 @@ Note: When creating a release, an asset is automatically compiled and attached t
 `composer run test;`
 
 Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, tests are automatically run (see [*PHP Composer* workflow](.github/workflows/tests.yml))
+
+### Conform to Standards
+
+Last [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)' rules.
+
+Conform code (using [PHP Coding Standards Fixer](https://cs.symfony.com/)): `composer run conform;`
+
+Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, conformity tests are automatically run (see [*PHP Composer* workflow](.github/workflows/standards.yml))
 
 ### Run Examples
 
@@ -473,14 +482,6 @@ for step in 1 1.1 1.2 2 3; do
     done;
 done;
 ```
-
-### Conform to Standards
-
-Last [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)' rules.
-
-Conform code (using [PHP Coding Standards Fixer](https://cs.symfony.com/)): `composer run conform;`
-
-Note: When a push to `develop` branch, to `master` branch or to a pull request targeting one of this two branches is done, conformity tests are automatically run (see [*PHP Composer* workflow](.github/workflows/standards.yml))
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ When `<step_number>` is **smaller than** the wanted step number, **execute `<act
 Available actions:
 * `KEEP` (`SOLUTION` and `WORKSHEET` states' default)
 * `COMMENT`
-* `REMOVE` (`PLACEHOLDER` state's default)`
+* `REMOVE` (`PLACEHOLDER` state's default)
 
 The following is equivalent:
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Step 2's solution:
 
 Tagged Reference:
 ```php
-protected function configure()
+protected function configure(): void
 {
     // TRAINING EXERCISE START STEP 1
     // TRAINING EXERCISE STEP PLACEHOLDER TODO: Set the description and the help
@@ -274,7 +274,7 @@ protected function configure()
 
 Step 1's worksheet:
 ```php
-protected function configure()
+protected function configure(): void
 {
     // TODO: Set the description and the help
 }
@@ -282,7 +282,7 @@ protected function configure()
 
 Step 1's solution:
 ```php
-protected function configure()
+protected function configure(): void
 {
     $this
         ->setDescription('Just an example')
@@ -293,7 +293,7 @@ protected function configure()
 
 Step 2's worksheet:
 ```php
-protected function configure()
+protected function configure(): void
 {
     $this
         ->setDescription('Just an example')
@@ -308,7 +308,7 @@ protected function configure()
 ```
 Step 2's solution (and next steps' worksheets and solutions):
 ```php
-protected function configure()
+protected function configure(): void
 {
     $this
         ->setDescription('Just an example')

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The tags include a step number as an integer or a float.
 
 The command get a step as an argument and will remove content inside tags having a greater one. When it's equal or smaller, see details in below subsections.
 
-The command get paths as arguments; for each given folder, if there is no dedicated extension, the script will first search recursively for files containing `TRAINING EXERCISE` (case sensitive), the core part of a starting tag.
+The command get paths as arguments; for each given folder, if there is no dedicated extension, the script will first search recursively for files containing `TRAINING EXERCISE` (case sensitive), the core part of a tag.
 
 A tag doesn't care if is embed in a comment or something else. When matching, the whole line containing the tag becomes the tag. For examples comment doesn't exist in JSON, there is some tricks to not trigger syntax errors but with a limitation for last line without ending comma.
 
@@ -472,6 +472,12 @@ for step in 1 1.1 1.2 2 3; do
     git checkout -- examples/example.sh;
 done;
 ```
+
+### Code Style
+
+Last [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)' rules.
+
+Using last [PHP Coding Standards Fixer](https://cs.symfony.com/): `php-cs-fixer fix --rules=@Symfony src/;`
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ done;
 
 Last [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)' rules.
 
-Using last [PHP Coding Standards Fixer](https://cs.symfony.com/): `php-cs-fixer fix --rules=@Symfony src/;`
+Using [PHP Coding Standards Fixer](https://cs.symfony.com/): `vendor/bin/php-cs-fixer fix --rules=@Symfony src/;` — Note: A `composer install --dev` (or alike) must have been previously executed.
 
 ### TODO
 

--- a/compile-phar.php
+++ b/compile-phar.php
@@ -15,7 +15,7 @@ $phar = new Phar($pharFileName);
 $phar->addFromString('src/Application.php', preg_replace('@\$version = .+;@', "\$version = '$version';", file_get_contents('src/Application.php')));
 $phar->setStub("#!/usr/bin/env php\n".Phar::createDefaultStub('src/Application.php'));
 
-// Remove dev dependencies (like phpunit)
+// Remove dev dependencies (like phpunit or php-cs-fixer)
 shell_exec('composer install --no-dev --quiet;');
 
 foreach ([

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "scripts": {
         "test": [
             "composer install --quiet --no-scripts",
-            "vendor/bin/phpunit --colors tests"
+            "vendor/bin/phpunit --colors=always tests"
         ],
         "conform":  [
             "composer install --quiet --no-scripts",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "symfony/yaml": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1"
+        "phpunit/phpunit": "^9.1",
+        "friendsofphp/php-cs-fixer": "^2.16"
     },
     "scripts": {
         "test": "vendor/bin/phpunit tests"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,15 @@
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit tests"
+        "test": [
+            "composer install --quiet --no-scripts",
+            "vendor/bin/phpunit --colors tests"
+        ],
+        "conform":  [
+            "composer install --quiet --no-scripts",
+            "vendor/bin/php-cs-fixer fix --rules=@Symfony src/",
+            "vendor/bin/php-cs-fixer fix --rules=@Symfony tests/"
+        ],
+        "compile": "time php -d phar.readonly=Off compile-phar.php"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f869740eaae6553e01234d9933fcc99f",
+    "content-hash": "0d22bec4eb60b4cdce0e6fc5eb062415",
     "packages": [
         {
             "name": "psr/container",
@@ -496,6 +496,186 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/semver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2020-01-13T12:06:48+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/1ab9842d69e64fb3a01be6b656501032d1b78cb7",
+                "reference": "1ab9842d69e64fb3a01be6b656501032d1b78cb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-03-01T12:26:26+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5db60a4969eba0e0c197a19c077780aadbc43c5d",
+                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^7.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2020-05-25T17:24:27+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.3.0",
             "source": {
@@ -552,6 +732,179 @@
             "time": "2019-10-21T16:45:58+00:00"
         },
         {
+            "name": "doctrine/lexer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.16.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/83baf823a33a1cbd5416c8626935cf3f843c10b0",
+                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.2",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.2",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.8",
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-15T18:51:10+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.9.5",
             "source": {
@@ -598,6 +951,51 @@
                 "object graph"
             ],
             "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -700,6 +1098,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1332,6 +1781,99 @@
                 }
             ],
             "time": "2020-04-23T04:42:05+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -2008,6 +2550,612 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2020-01-21T06:36:37+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "24f40d95385774ed5c71dbf014edd047e2f2f3dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/24f40d95385774ed5c71dbf014edd047e2f2f3dc",
+                "reference": "24f40d95385774ed5c71dbf014edd047e2f2f3dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/event-dispatcher-contracts": "^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/af23c2584d4577d54661c434446fb8fbed6025dd",
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "7cd0dafc4353a0f62e307df90b48466379c8cc91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7cd0dafc4353a0f62e307df90b48466379c8cc91",
+                "reference": "7cd0dafc4353a0f62e307df90b48466379c8cc91",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-12T14:40:17+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/600a52c29afc0d1caa74acbec8d3095ca7e9910d",
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "3707e3caeff2b797c0bfaadd5eba723dd44e6bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/3707e3caeff2b797c0bfaadd5eba723dd44e6bf1",
+                "reference": "3707e3caeff2b797c0bfaadd5eba723dd44e6bf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-06T10:40:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "82225c2d7d23d7e70515496d249c0152679b468e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/82225c2d7d23d7e70515496d249c0152679b468e",
+                "reference": "82225c2d7d23d7e70515496d249c0152679b468e",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T16:47:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/f048e612a3905f34931127360bdd2def19a5e582",
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T16:47:27+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-15T15:59:10+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "a1d86d30d4522423afc998f32404efa34fcf5a73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/a1d86d30d4522423afc998f32404efa34fcf5a73",
+                "reference": "a1d86d30d4522423afc998f32404efa34fcf5a73",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/examples/ExampleCommand.php
+++ b/examples/ExampleCommand.php
@@ -10,7 +10,7 @@ class ExampleCommand extends Command
 {
     protected static $defaultName = 'app:example';
 
-    protected function configure()
+    protected function configure(): void
     {
         // TRAINING EXERCISE START STEP 1
         // TRAINING EXERCISE STEP PLACEHOLDER TODO: Set the description and the help

--- a/examples/ExampleCommand.php
+++ b/examples/ExampleCommand.php
@@ -16,7 +16,7 @@ class ExampleCommand extends Command
         // TRAINING EXERCISE STEP PLACEHOLDER TODO: Set the description and the help
         $this
             ->setDescription('Just an example')
-            // TRAINING EXERCISE START STEP 1 COMMENT
+            // TRAINING EXERCISE START STEP 1 COMMENT Internal Note: Is the parse error in the complete file can be fixed?
             ->setHelp('Step 1 feature');
             // TRAINING EXERCISE STOP STEP 1
             // TRAINING EXERCISE START STEP 2

--- a/examples/ExampleCommand.php
+++ b/examples/ExampleCommand.php
@@ -16,13 +16,22 @@ class ExampleCommand extends Command
         // TRAINING EXERCISE STEP PLACEHOLDER TODO: Set the description and the help
         $this
             ->setDescription('Just an example')
-            // TRAINING EXERCISE START STEP 1 COMMENT Internal Note: Is the parse error in the complete file can be fixed?
-            ->setHelp('Step 1 feature');
+            // TRAINING EXERCISE START STEP 1 COMMENT
+            ->setHelp('Step 1 feature')
             // TRAINING EXERCISE STOP STEP 1
-            // TRAINING EXERCISE START STEP 2
-            // TRAINING EXERCISE STEP PLACEHOLDER TODO: Update the description
-            ->setHelp("Step 1 feature\nStep 2 feature");
+            // TRAINING EXERCISE START STEP 2 PLACEHOLDER
+            /* TODO:
+                - Add argument(s)
+                - Add option(s)
+                - Update help
+            */
             // TRAINING EXERCISE STOP STEP 2
+            // TRAINING EXERCISE START STEP 2
+            ->addArgument('argument', InputArgument::OPTIONAL, 'An optional argument')
+            ->addOption('option', 'o', InputOption::VALUE_OPTIONAL, 'An option with an optional value')
+            ->setHelp("Step 1 feature\nStep 2 feature")
+            // TRAINING EXERCISE STOP STEP 2
+        ;
         // TRAINING EXERCISE STOP STEP 1
     }
 

--- a/examples/example.ini
+++ b/examples/example.ini
@@ -16,7 +16,7 @@ pm.max_children=32
 pm.min_spare_servers=4
 pm.max_spare_servers=16
 ; TRAINING EXERCISE STOP STEP 1.1 SOLUTION
-; TRAINING EXERCISE START STEP 1.2 PLACEHOLDER Trainer Note: Ask to trainees “How many threads/servers are available on start-up?”, show the formula ‘min_spare_servers + (max_spare_servers - min_spare_servers) / 2’ on https://www.php.net/manual/fr/install.fpm.configuration.php
+; TRAINING EXERCISE START STEP 1.2 PLACEHOLDER Note to Trainer: Ask to trainees “How many threads/servers are available on start-up?”, show the formula ‘min_spare_servers + (max_spare_servers - min_spare_servers) / 2’ on https://www.php.net/manual/fr/install.fpm.configuration.php
 ; Set as many started servers as minimum spare servers
 ; TRAINING EXERCISE STOP STEP 1.2 PLACEHOLDER
 ; TRAINING EXERCISE START STEP 1.2 SOLUTION

--- a/examples/example.ini
+++ b/examples/example.ini
@@ -1,0 +1,25 @@
+; TRAINING EXERCISE START STEP 1.0 COMMENT
+pm=static
+; TRAINING EXERCISE STOP STEP 1.0 COMMENT
+; TRAINING EXERCISE START STEP 1.1 SOLUTION
+pm=dynamic
+; TRAINING EXERCISE STOP STEP 1.1 SOLUTION
+; TRAINING EXERCISE START STEP 1.0 SOLUTION
+pm.max_children=32
+; TRAINING EXERCISE STOP STEP 1.0 SOLUTION
+; TRAINING EXERCISE START STEP 1.1 PLACEHOLDER
+; Do not get always 32 threads running
+; A minimum of 4 available idle children
+; A maximum of 16 idle children
+; TRAINING EXERCISE STOP STEP 1.1 PLACEHOLDER
+; TRAINING EXERCISE START STEP 1.1 SOLUTION
+pm.min_spare_servers=4
+pm.max_spare_servers=16
+; TRAINING EXERCISE STOP STEP 1.1 SOLUTION
+; TRAINING EXERCISE START STEP 1.2 PLACEHOLDER Trainer Note: Ask to trainees “How many threads/servers are available on start-up?”, show the formula ‘min_spare_servers + (max_spare_servers - min_spare_servers) / 2’ on https://www.php.net/manual/fr/install.fpm.configuration.php
+; Set as many started servers as minimum spare servers
+; TRAINING EXERCISE STOP STEP 1.2 PLACEHOLDER
+; TRAINING EXERCISE START STEP 1.2 SOLUTION
+; 4 instead of default 10 = 4 + (16-4)/2
+pm.start_servers=4
+; TRAINING EXERCISE STOP STEP 1.2 SOLUTION

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -5,16 +5,16 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/symfony
         https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-    <!-- TRAINING EXERCISE START STEP 1  -->
+    <!-- TRAINING EXERCISE START STEP 1 -->
     <imports>
     </imports>
     <parameters>
-        <!-- TRAINING EXERCISE START STEP 1.1 COMMENT  -->
+        <!-- TRAINING EXERCISE START STEP 1.1 COMMENT -->
         <parameter key="example">test</parameter>
-        <!-- TRAINING EXERCISE STOP STEP 1.1  -->
-        <!-- TRAINING EXERCISE START STEP 2  -->
+        <!-- TRAINING EXERCISE STOP STEP 1.1 -->
+        <!-- TRAINING EXERCISE START STEP 2 -->
         <parameter key="example">test</parameter>
-        <!-- TRAINING EXERCISE STOP STEP 2  -->
+        <!-- TRAINING EXERCISE STOP STEP 2 -->
     </parameters>
-    <!-- TRAINING EXERCISE STOP STEP 1  -->
+    <!-- TRAINING EXERCISE STOP STEP 1 -->
 </container>

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -1,0 +1,20 @@
+<?xml vers-ion="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony
+        https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+    <!-- TRAINING EXERCISE START STEP 1  -->
+    <imports>
+    </imports>
+    <parameters>
+        <!-- TRAINING EXERCISE START STEP 1.1 COMMENT  -->
+        <parameter key="example">test</parameter>
+        <!-- TRAINING EXERCISE STOP STEP 1.1  -->
+        <!-- TRAINING EXERCISE START STEP 2  -->
+        <parameter key="example">test</parameter>
+        <!-- TRAINING EXERCISE STOP STEP 2  -->
+    </parameters>
+    <!-- TRAINING EXERCISE STOP STEP 1  -->
+</container>

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,7 +13,7 @@ switch ($version) {
         $ref = 'develop';
         break;
     default:
-        if (preg_match('@(?<version>v.*)-[0-9]-g(?<commit>[0-9a-f]{7})$@', $version, $matches)) {
+        if (preg_match('@(?<version>v.*)-(?<additional_commits>[0-9]+)-g(?<commit>[0-9a-f]{7})$@', $version, $matches)) {
             $ref = $matches['commit'];
         } else {
             $ref = $version;

--- a/src/DefaultSingleCommand.php
+++ b/src/DefaultSingleCommand.php
@@ -17,7 +17,7 @@ class DefaultSingleCommand extends Command
     /** @var bool */
     private $isPhar;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Prepare files for an exercise or its solution at a given step')
@@ -37,7 +37,7 @@ class DefaultSingleCommand extends Command
         $this->isPhar = Utils::isPhar();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->getFormatter()->setStyle('warning', new OutputFormatterStyle('white', 'yellow'));
 

--- a/src/DefaultSingleCommand.php
+++ b/src/DefaultSingleCommand.php
@@ -14,9 +14,6 @@ class DefaultSingleCommand extends Command
 {
     protected static $defaultName = 'exercise-cleaner.phar';
 
-    /** @var bool */
-    private $isPhar;
-
     protected function configure(): void
     {
         $this
@@ -33,8 +30,6 @@ class DefaultSingleCommand extends Command
             ->addArgument('step', InputArgument::OPTIONAL, 'Remove inside tags having this step float and greater.', 1)
             ->addArgument('paths', InputArgument::IS_ARRAY, 'Search inside this folder(s).', ['app', 'src'])
         ;
-
-        $this->isPhar = Utils::isPhar();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -61,10 +56,7 @@ class DefaultSingleCommand extends Command
         if ($this->getDefinition()->hasOption('config')) {
             $configFile = $input->getOption('config');
             if (!is_null($configFile)) {
-                if ($this->isPhar) {
-                    $configFile = Utils::getAbsolutePath($configFile);
-                }
-                if (is_file($configFile)) {
+                if (is_file(realpath($configFile))) {
                     switch (pathinfo($configFile, PATHINFO_EXTENSION)) {
                         case 'yaml':
                         case 'yml':

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -379,6 +379,9 @@ class ExerciseCleaner
 
     private function getLocationMessage(int $lineNumber = null, string $file = null): string
     {
+        if ($this->isPhar) {
+            $file = Utils::getRelativePath($file);
+        }
         return ($file ? " in $file" : '').($lineNumber ? " on line $lineNumber" : '');
     }
 

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -167,7 +167,7 @@ class ExerciseCleaner
 
         $intro = false !== strpos($line, 'INTRO'); // backward compatibility
         if ($intro) {
-            trigger_error("INTRO keyword is deprecated (WORKSHEET should be used instead){$this->getLocationMessage($lineNumber, $file)}", E_USER_DEPRECATED);
+            trigger_error("WORKSHEET state should be used instead of INTRO keyword{$this->getLocationMessage($lineNumber, $file)}", E_USER_DEPRECATED);
             $line = trim(str_replace('  ', ' ', str_replace('INTRO', '', $line)));
             $line = preg_replace('/(TRAINING EXERCISE (?<boundary>START|STOP) STEP (?<step>[.0-9]+))/', '$1 WORKSHEET', $line);
         }

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -32,7 +32,7 @@ class ExerciseCleaner
                     if (is_numeric($index) && is_string($name)) {
                         $stepNames["step_$index"] = $name;
                     } elseif (is_array($name) && array_key_exists('name', $name)) {
-                        $stepNames['step_' . (array_key_exists('n', $name) ? $name['n'] : $name['number'])] = $name['name'];
+                        $stepNames['step_'.(array_key_exists('n', $name) ? $name['n'] : $name['number'])] = $name['name'];
                     }
                 }
                 $config['steps']['names'] = $stepNames;
@@ -62,23 +62,23 @@ class ExerciseCleaner
                         $keptLines[] = $line;
                     }
 
-                    $this->outputWrite("Start step {$tag['step']}" . ($tag['name'] ? " “{$tag['name']}”" : '') . " at line $lineNumber:", OutputInterface::VERBOSITY_VERY_VERBOSE);
-                    $this->outputWrite($this->getActionVerb($tag, $targetStep) . '…', OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->outputWrite("Start step {$tag['step']}".($tag['name'] ? " “{$tag['name']}”" : '')." at line $lineNumber:", OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->outputWrite($this->getActionVerb($tag, $targetStep).'…', OutputInterface::VERBOSITY_VERY_VERBOSE);
                 } else {
                     $stoppedTag = array_pop($nestedTags);
                     if ($tag['step'] !== $stoppedTag['step']) {
-                        trigger_error('Parse Error: STOP tag not matching START tag' . ($file ? " in file $file" : '') . " at line $lineNumber", E_USER_ERROR);
+                        trigger_error('Parse Error: STOP tag not matching START tag'.($file ? " in file $file" : '')." at line $lineNumber", E_USER_ERROR);
                     }
 
                     if ($keepTags && $tag['step'] <= $targetStep) {
                         $keptLines[] = $line;
                     }
 
-                    $this->outputWrite("Stop step {$tag['step']}" . ($stoppedTag['name'] ? " “{$stoppedTag['name']}”" : '') . " at line $lineNumber.", OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->outputWrite("Stop step {$tag['step']}".($stoppedTag['name'] ? " “{$stoppedTag['name']}”" : '')." at line $lineNumber.", OutputInterface::VERBOSITY_VERY_VERBOSE);
                     if (count($nestedTags)) {
                         $currentTag = $nestedTags[count($nestedTags) - 1];
-                        $this->outputWrite("Reenter step {$currentTag['step']}" . ($currentTag['name'] ? " “{$currentTag['name']}”" : '') . " at line $lineNumber:", OutputInterface::VERBOSITY_VERY_VERBOSE);
-                        $this->outputWrite($this->getActionVerb($currentTag, $targetStep) . '…', OutputInterface::VERBOSITY_VERY_VERBOSE);
+                        $this->outputWrite("Reenter step {$currentTag['step']}".($currentTag['name'] ? " “{$currentTag['name']}”" : '')." at line $lineNumber:", OutputInterface::VERBOSITY_VERY_VERBOSE);
+                        $this->outputWrite($this->getActionVerb($currentTag, $targetStep).'…', OutputInterface::VERBOSITY_VERY_VERBOSE);
                     }
                 }
             } elseif (count($nestedTags)) {
@@ -96,7 +96,7 @@ class ExerciseCleaner
                         case 'COMMENT':
                             if (null !== $commentPattern) {
                                 preg_match('@^(?<indent> *)(?<code>.*)$@', $line, $matches);
-                                $keptLines[] = ($matches['indent'] ?? '') . str_replace('%CODE%', $matches['code'] ?? '', $commentPattern);
+                                $keptLines[] = ($matches['indent'] ?? '').str_replace('%CODE%', $matches['code'] ?? '', $commentPattern);
                             }
                             break;
                         case 'REMOVE':
@@ -123,10 +123,10 @@ class ExerciseCleaner
                             $keptLines[] = $line;
                             break;
                         case 'SOLUTION':
-                        default;
+                        default:
                             if ($solution && false === strpos($line, $this->placeholderTagConstant)) {
                                 $keptLines[] = $line;
-                            } else if (!$solution && false !== strpos($line, $this->placeholderTagConstant)) {
+                            } elseif (!$solution && false !== strpos($line, $this->placeholderTagConstant)) {
                                 $keptLines[] = preg_replace("@ *{$this->placeholderTagConstant}@", '', $line);
                             }
                             break;
@@ -147,21 +147,22 @@ class ExerciseCleaner
     {
         $intro = false !== strpos($line, 'INTRO'); // backward compatibility
         if ($intro) {
-            trigger_error('INTRO keyword is deprecated, WORKSHEET should be used instead; ' . ($file ? " in file $file" : '') . " at line $lineNumber", E_USER_DEPRECATED);
+            trigger_error('INTRO keyword is deprecated, WORKSHEET should be used instead; '.($file ? " in file $file" : '')." at line $lineNumber", E_USER_DEPRECATED);
             $line = trim(str_replace('  ', ' ', str_replace('INTRO', '', $line)));
         }
 
         preg_match($this->tagRegex, $line, $matches);
 
         if (!count($matches)) {
-            trigger_error('Parse Error' . ($file ? " in file $file" : '') . ($lineNumber ? " at line $lineNumber" : ''), E_USER_ERROR);
+            trigger_error('Parse Error'.($file ? " in file $file" : '').($lineNumber ? " at line $lineNumber" : ''), E_USER_ERROR);
+
             return [];
-            throw new \ParseError('Parse Error' . ($file ? " in file $file" : '') . ($lineNumber ? " at line $lineNumber" : ''));
+            throw new \ParseError('Parse Error'.($file ? " in file $file" : '').($lineNumber ? " at line $lineNumber" : ''));
         }
         $tag = [
             'boundary' => $matches['boundary'],
             'start' => 'START' === $matches['boundary'],
-            'step' => (float)$matches['step'],
+            'step' => (float) $matches['step'],
         ];
 
         if ($tag['start']) {
@@ -198,7 +199,7 @@ class ExerciseCleaner
                 $tag['action'] = "{$tag['before']} UNTIL {$tag['threshold']} THEN {$tag['after']}";
 
                 if ($tag['threshold'] <= $tag['step']) {
-                    trigger_error('Threshold less or equals to step' . ($file ? " in file $file" : '') . " at line $lineNumber", E_USER_WARNING);
+                    trigger_error('Threshold less or equals to step'.($file ? " in file $file" : '')." at line $lineNumber", E_USER_WARNING);
                 }
             }
 
@@ -210,22 +211,39 @@ class ExerciseCleaner
         return $tag;
     }
 
+    /**
+     * Get the comment pattern for a file type.
+     *
+     * @param string|null $file file name, file path or file extension; If not given, return number sign “#” comment pattern
+     *
+     * @return string|null a pattern with %CODE% as placeholder; or, null if language is not supported or doesn't support comments
+     */
     private function getCommentPattern(string $file = null): ?string
     {
+        if (null !== $file && false === strpos($file, '.')) {
+            // Only the extension has been given instead of full file name or path.
+            $file = ".$file";
+        }
         switch ($file ? pathinfo($file, PATHINFO_EXTENSION) : null) {
-            case 'json':
-                return null; // There is no comment in JSON
+            case 'html':
+            case 'xml':
+                return '<!-- %CODE% -->';
+            case 'ini':
+                return '; %CODE%';
             case 'twig':
                 return '{# %CODE% #}';
             case 'php':
                 return '// %CODE%';
+            case null: // Default if no argument; Available in PHP and several shell script languages
             case 'sh':
             case 'zsh':
             case 'bash':
             case 'yaml':
             case 'yml':
-            default:
                 return '# %CODE%';
+            case 'json': // There is no comment in JSON
+            default: // Default if unhandled file type
+                return null;
         }
     }
 

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -379,7 +379,7 @@ class ExerciseCleaner
 
     private function getLocationMessage(int $lineNumber = null, string $file = null): string
     {
-        return ($file ? " in file $file" : '').($lineNumber ? " on line $lineNumber" : '');
+        return ($file ? " in $file" : '').($lineNumber ? " on line $lineNumber" : '');
     }
 
     private function writeToOutput($messages, $verbosity = OutputInterface::VERBOSITY_NORMAL)

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -147,20 +147,21 @@ class ExerciseCleaner
     {
         $intro = false !== strpos($line, 'INTRO'); // backward compatibility
         if ($intro) {
-            trigger_error('INTRO keyword is deprecated, WORKSHEET should be used instead.', E_USER_DEPRECATED);
+            trigger_error('INTRO keyword is deprecated, WORKSHEET should be used instead; ' . ($file ? " in file $file" : '') . " at line $lineNumber", E_USER_DEPRECATED);
             $line = trim(str_replace('  ', ' ', str_replace('INTRO', '', $line)));
         }
 
         preg_match($this->tagRegex, $line, $matches);
 
-        if (empty($matches['step'])) {
-            trigger_error('Parse Error: Step number is missing' . ($file ? " in file $file" : '') . " at line $lineNumber", E_USER_ERROR);
+        if (!count($matches)) {
+            trigger_error('Parse Error' . ($file ? " in file $file" : '') . ($lineNumber ? " at line $lineNumber" : ''), E_USER_ERROR);
+            return [];
+            throw new \ParseError('Parse Error' . ($file ? " in file $file" : '') . ($lineNumber ? " at line $lineNumber" : ''));
         }
-
         $tag = [
-            'step' => (float)$matches['step'],
             'boundary' => $matches['boundary'],
             'start' => 'START' === $matches['boundary'],
+            'step' => (float)$matches['step'],
         ];
 
         if ($tag['start']) {

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -155,13 +155,13 @@ class ExerciseCleaner
     }
 
     /**
-     * Parse enclosing tag and return tag properties
+     * Parse enclosing tag and return tag properties.
      */
     public function parseTag(string $line, int $lineNumber = null, string $file = null): ?array
     {
         if (false === strpos($line, $this->tagConstant)) {
             throw new \InvalidArgumentException('Not a tag');
-        } else if (false !== strpos($line, $this->placeholderTagConstant)) {
+        } elseif (false !== strpos($line, $this->placeholderTagConstant)) {
             throw new \InvalidArgumentException('Not an enclosing tag but a one-line tag');
         }
         $intro = false !== strpos($line, 'INTRO'); // backward compatibility

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -50,7 +50,6 @@ class ExerciseCleaner
         $keptLines = [];
         $nestedTags = [];
         $commentPattern = $this->getCommentPattern($file);
-        $lineNumber = 0;
 
         foreach ($lines as $lineIndex => $line) {
             $lineNumber = 1 + $lineIndex;
@@ -161,14 +160,16 @@ class ExerciseCleaner
     {
         if (false === strpos($line, $this->tagConstant)) {
             throw new \InvalidArgumentException('Not a tag');
-        } elseif (false !== strpos($line, $this->placeholderTagConstant)) {
+        }
+        if (false !== strpos($line, $this->placeholderTagConstant)) {
             throw new \InvalidArgumentException('Not an enclosing tag but a one-line tag');
         }
+
         $intro = false !== strpos($line, 'INTRO'); // backward compatibility
         if ($intro) {
             trigger_error("INTRO keyword is deprecated (WORKSHEET should be used instead){$this->getLocationMessage($lineNumber, $file)}", E_USER_DEPRECATED);
             $line = trim(str_replace('  ', ' ', str_replace('INTRO', '', $line)));
-            $line = preg_replace('/(TRAINING EXERCISE (?<boundary>START|STOP) STEP (?<step>[\.0-9]+))/', '$1 WORKSHEET', $line);
+            $line = preg_replace('/(TRAINING EXERCISE (?<boundary>START|STOP) STEP (?<step>[.0-9]+))/', '$1 WORKSHEET', $line);
         }
 
         preg_match($this->tagRegex, $line, $matches);

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -289,10 +289,7 @@ class ExerciseCleaner
             if ('' === $path) {
                 continue;
             }
-            if ($this->isPhar) {
-                $path = Utils::getAbsolutePath($path);
-            }
-            if (is_dir($path)) {
+            if (is_dir(realpath($path))) {
                 if ('/' === substr($path, -1)) {
                     // Avoid double slashes in find or grep result
                     $path = substr($path, 0, -1);
@@ -306,7 +303,7 @@ class ExerciseCleaner
                     }
                 }
                 $fileList = Utils::getFileListFromShellCmd("$cmd;");
-            } elseif (is_file($path)) {
+            } elseif (is_file(realpath($path))) {
                 $fileList = [$path];
             } else {
                 trigger_error("$path is not a file nor a directory", E_USER_WARNING);
@@ -314,7 +311,7 @@ class ExerciseCleaner
             }
             foreach ($fileList as $inputFile) {
                 $this->writeToOutput("<info>Treat {$inputFile}…</info>", OutputInterface::VERBOSITY_VERBOSE);
-                if (!is_file($inputFile)) {
+                if (!is_file(realpath($inputFile))) {
                     trigger_error("$path is not a file", E_USER_WARNING);
                     continue;
                 }
@@ -379,9 +376,6 @@ class ExerciseCleaner
 
     private function getLocationMessage(int $lineNumber = null, string $file = null): string
     {
-        if ($this->isPhar) {
-            $file = Utils::getRelativePath($file);
-        }
         return ($file ? " in $file" : '').($lineNumber ? " on line $lineNumber" : '');
     }
 

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -246,6 +246,8 @@ class ExerciseCleaner
         }
         switch ($file ? pathinfo($file, PATHINFO_EXTENSION) : null) {
             case 'html':
+            case 'md':
+            case 'xhtml':
             case 'xml':
                 return '<!-- %CODE% -->';
             case 'ini':

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -10,9 +10,6 @@ class ExerciseCleaner
     public $tagRegex = '/TRAINING EXERCISE (?<boundary>START|STOP) STEP (?<step>[\.0-9]+) ?(?<state>PLACEHOLDER|SOLUTION|WORKSHEET)? ?(?<action>COMMENT|KEEP|REMOVE)? ?(UNTIL (?<threshold_step>[\.0-9]+))? ?(THEN (?<threshold_action>COMMENT|KEEP|REMOVE))?/';
     public $placeholderTagConstant = 'TRAINING EXERCISE STEP PLACEHOLDER';
 
-    /** @var bool */
-    private $isPhar;
-
     /** @var array|null */
     private $config;
 
@@ -21,9 +18,6 @@ class ExerciseCleaner
 
     public function __construct(array $config = null, OutputInterface $output = null)
     {
-        // Executable Phar
-        $this->isPhar = Utils::isPhar();
-
         if (!is_null($config)) {
             // Step Names Parsing
             if (array_key_exists('steps', $config) && array_key_exists('names', $config['steps'])) {

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -53,7 +53,7 @@ class ExerciseCleaner
 
         foreach ($lines as $lineIndex => $line) {
             $lineNumber = 1 + $lineIndex;
-            if (false !== strpos($line, $this->tagConstant) && /* backward compatibility */ false === strpos($line, $this->placeholderTagConstant)) {
+            if (false !== strpos($line, $this->tagConstant) && false === strpos($line, $this->placeholderTagConstant)) {
                 $tag = $this->parseTag($line, $lineNumber, $file);
                 if ($tag['start']) {
                     $nestedTags[] = $tag;

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -379,7 +379,7 @@ class ExerciseCleaner
 
     private function getLocationMessage(int $lineNumber = null, string $file = null): string
     {
-        return ($file ? " in file $file" : '').($lineNumber ? " at line $lineNumber" : '');
+        return ($file ? " in file $file" : '').($lineNumber ? " on line $lineNumber" : '');
     }
 
     private function writeToOutput($messages, $verbosity = OutputInterface::VERBOSITY_NORMAL)

--- a/src/ExerciseCleaner.php
+++ b/src/ExerciseCleaner.php
@@ -107,9 +107,6 @@ class ExerciseCleaner
                             $keptLines[] = $line;
                     }
                 } elseif ($targetStep === $currentTag['step']) {
-                    //if (false !== strpos($line, $this->placeholderTagConstant)) {
-                    //    trigger_error("{$this->placeholderTagConstant} one-line tag is deprecated; TRAINING EXERCISE START STEP <n> PLACEHOLDER syntax should be used instead.", E_USER_DEPRECATED);
-                    //}
                     switch ($currentTag['state']) {
                         case 'PLACEHOLDER':
                             if (!$solution) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -19,23 +19,4 @@ class Utils
 
         return $fileList;
     }
-
-    public static function getAbsolutePath(string $relativePath): string
-    {
-        return realpath($relativePath);
-    }
-
-    public static function getRelativePath(string $absolutePath): string
-    {
-        if (0 === strpos($absolutePath, '/')) {
-            return str_replace(trim(`pwd`), '.', $absolutePath);
-        }
-
-        return $absolutePath;
-    }
-
-    public static function isPhar(): bool
-    {
-        return (bool) preg_match('@^phar:///@', __DIR__);
-    }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -29,6 +29,15 @@ class Utils
         return $relativePath;
     }
 
+    public static function getRelativePath(string $absolutePath): string
+    {
+        if ('' !== $absolutePath && '/' === $absolutePath[0]) {
+            return str_replace(trim(`pwd`), '.', $absolutePath);
+        }
+
+        return $absolutePath;
+    }
+
     public static function isPhar(): bool
     {
         return (bool) preg_match('@^phar:///@', __DIR__);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -27,7 +27,7 @@ class Utils
 
     public static function getRelativePath(string $absolutePath): string
     {
-        if ('' !== $absolutePath && '/' === $absolutePath[0]) {
+        if (0 === strpos($absolutePath, '/')) {
             return str_replace(trim(`pwd`), '.', $absolutePath);
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -22,11 +22,7 @@ class Utils
 
     public static function getAbsolutePath(string $relativePath): string
     {
-        if ('' !== $relativePath && '/' !== $relativePath[0]) {
-            return trim(`pwd`)."/$relativePath";
-        }
-
-        return $relativePath;
+        return realpath($relativePath);
     }
 
     public static function getRelativePath(string $absolutePath): string

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -117,24 +117,25 @@ class ExerciseCleanerTest extends TestCase
             'state' => 'WORKSHEET',
             'action' => 'KEEP',
         ];
+        $deprecatedIntroMessage = 'WORKSHEET state should be used instead of INTRO keyword';
         foreach ([
                      'TRAINING EXERCISE START STEP 1 INTRO' => [
-                         'msg' => 'INTRO keyword is deprecated',
+                         'msg' => $deprecatedIntroMessage,
                          'type' => E_USER_DEPRECATED,
                          'parsed' => $parsedIntroTag,
                      ],
                      'TRAINING EXERCISE START STEP INTRO 1' => [
-                         'msg' => 'INTRO keyword is deprecated',
+                         'msg' => $deprecatedIntroMessage,
                          'type' => E_USER_DEPRECATED,
                          'parsed' => $parsedIntroTag,
                      ],
                      'TRAINING EXERCISE START INTRO STEP 1' => [
-                         'msg' => 'INTRO keyword is deprecated',
+                         'msg' => $deprecatedIntroMessage,
                          'type' => E_USER_DEPRECATED,
                          'parsed' => $parsedIntroTag,
                      ],
                      'TRAINING EXERCISE INTRO START STEP 1' => [
-                         'msg' => 'INTRO keyword is deprecated',
+                         'msg' => $deprecatedIntroMessage,
                          'type' => E_USER_DEPRECATED,
                          'parsed' => $parsedIntroTag,
                      ],
@@ -533,7 +534,7 @@ CODE;
 
         $this->assertEquals(['Step 1 Introduction', 'Steps 1 & 2 Introduction'], $this->exerciseCleaner->cleanCodeLines($codeLines, 1, false));
         $this->assertEquals(['Step 1 Introduction', 'Steps 1 & 2 Introduction', 'Step 1 Solution'], $this->exerciseCleaner->cleanCodeLines($codeLines, 1, true));
-        $this->assertStringContainsString('INTRO keyword is deprecated', $this->getLastErrorMessage());
+        $this->assertStringContainsString('WORKSHEET state should be used instead of INTRO keyword', $this->getLastErrorMessage());
         $this->assertEquals(E_USER_DEPRECATED, $this->getLastErrorType());
 
         $this->assertEquals(['Steps 1 & 2 Introduction', 'Step 2+ Introduction'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.php'));

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -22,6 +22,9 @@ class ExerciseCleanerTest extends TestCase
         $this->assertStringContainsString($this->exerciseCleaner->tagConstant, $this->exerciseCleaner->tagRegex);
     }
 
+    /*********************/
+    /* Tag Parsing Tests */
+
     public function testParseTag(): void
     {
         foreach ([
@@ -96,59 +99,102 @@ class ExerciseCleanerTest extends TestCase
                          'after' => 'COMMENT',
                      ],
                  ] as $line => $parsedTag) {
+            $parsedTag['tag'] = $this->cleanTag($line);
+            $parsedTag['line_number'] = null;
+
             $this->assertEquals($parsedTag, $this->exerciseCleaner->parseTag($line));
         }
     }
 
-    //public function testParseTagBackwardCompatibility(): void
-    //{
-    //TODO
-    //}
+    public function testParseTagBackwardCompatibility(): void
+    {
+        $parsedIntroTag = [
+            'tag' => 'TRAINING EXERCISE START STEP 1 WORKSHEET',
+            'boundary' => 'START',
+            'start' => true,
+            'step' => 1,
+            'name' => null,
+            'state' => 'WORKSHEET',
+            'action' => 'KEEP',
+        ];
+        foreach ([
+                     'TRAINING EXERCISE START STEP 1 INTRO' => [
+                         'msg' => 'INTRO keyword is deprecated',
+                         'type' => E_USER_DEPRECATED,
+                         'parsed' => $parsedIntroTag,
+                     ],
+                     'TRAINING EXERCISE START STEP INTRO 1' => [
+                         'msg' => 'INTRO keyword is deprecated',
+                         'type' => E_USER_DEPRECATED,
+                         'parsed' => $parsedIntroTag,
+                     ],
+                     'TRAINING EXERCISE START INTRO STEP 1' => [
+                         'msg' => 'INTRO keyword is deprecated',
+                         'type' => E_USER_DEPRECATED,
+                         'parsed' => $parsedIntroTag,
+                     ],
+                     'TRAINING EXERCISE INTRO START STEP 1' => [
+                         'msg' => 'INTRO keyword is deprecated',
+                         'type' => E_USER_DEPRECATED,
+                         'parsed' => $parsedIntroTag,
+                     ],
+                 ] as $line => $feedback) {
+            $parsedTag = $this->exerciseCleaner->parseTag($line);
+
+            if (!array_key_exists('tag', $feedback['parsed'])) {
+                $feedback['parsed']['tag'] = $this->cleanTag($line);
+            }
+            $feedback['parsed']['line_number'] = null;
+
+            $this->assertEquals($feedback['parsed'], $parsedTag);
+            $this->assertEquals($feedback['type'], $this->getLastErrorType());
+            $this->assertStringContainsString($feedback['msg'], $this->getLastErrorMessage());
+        }
+    }
 
     public function testParseTagError(): void
     {
         foreach ([
-                     'TRAINING EXERCISE' => [
-                         'msg' => 'Parse Error',
-                         'type' => E_USER_ERROR,
-                     ],
-                     'TRAINING EXERCISE START' => [
-                         'msg' => 'Parse Error',
-                         'type' => E_USER_ERROR,
-                     ],
-                     'TRAINING EXERCISE START STEP' => [
-                         'msg' => 'Parse Error',
-                         'type' => E_USER_ERROR,
-                     ],
-                     'TRAINING EXERCISE START STEP Test' => [
-                         'msg' => 'Parse Error',
-                         'type' => E_USER_ERROR,
-                     ],
-                     'TRAINING EXERCISE START STEP 1 UNKNOWN' => [
-                         'msg' => 'Parse Error',
-                         'type' => E_USER_ERROR,
-                     ],
-                    'TRAINING EXERCISE START STEP 1 INTRO' => [
-                        'msg' => 'INTRO keyword is deprecated',
-                        'type' => E_USER_DEPRECATED,
-                        'parsed' => [
-                            'boundary' => 'START',
-                            'start' => true,
-                            'step' => 1,
-                            'name' => null,
-                            'state' => 'WORKSHEET',
-                            'action' => 'KEEP',
-                        ],
-                    ],
-                 ] as $line => $feedback) {
-            $parsedTag = $this->exerciseCleaner->parseTag($line);
-            $this->assertEquals($feedback['type'], $this->getLastErrorType());
-            $this->assertStringContainsString($feedback['msg'], $this->getLastErrorMessage());
-            if (E_USER_ERROR !== $this->getLastErrorType()) {
-                $this->assertEquals($feedback['parsed'], $parsedTag);
+                     'TRAINING EXERCISE',
+                     'TRAINING EXERCISE START',
+                     'TRAINING EXERCISE START STEP',
+                     'TRAINING EXERCISE START STEP Test',
+                 ] as $line) {
+            //$this->expectException(\ParseError::class); // Can't be used several times
+            try {
+                $this->exerciseCleaner->parseTag($line);
+                $this->fail("No ParseError thrown while parsing “{$line}”");
+            } catch (\ParseError $parseError) {
+                $this->assertStringContainsStringIgnoringCase('tag parse error', $parseError->getMessage());
             }
         }
     }
+
+    public function testNotATagError(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not a tag');
+        $this->exerciseCleaner->parseTag('TRAINING EXERCICE');
+    }
+
+    public function testNotAnEnclosingTagError(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not an enclosing tag');
+        $this->exerciseCleaner->parseTag($this->exerciseCleaner->placeholderTagConstant);
+    }
+
+    /** Do not parse, simply remove non alpha-numeric characters */
+    private function cleanTag(string $tag): string
+    {
+        $tag = preg_replace('/^[^A-Z0-9\.]*/', '', $tag);
+        $tag = preg_replace('/[^A-Z0-9\.]*$/', '', $tag);
+
+        return trim($tag);
+    }
+
+    /***********************/
+    /* Code Cleaning Tests */
 
     public function testSimplestTag()
     {
@@ -547,7 +593,10 @@ CODE;
         ], $cleanedCodeLines);
     }
 
-    public function testParseError(): void
+    /*****************/
+    /* Error Testing */
+
+    public function testEnclosureParseError(): void
     {
         $code = <<<'CODE'
 1 # TRAINING EXERCISE START STEP 1
@@ -560,9 +609,62 @@ CODE;
 
         $this->exerciseCleaner->cleanCodeLines($codeLines);
 
-        $this->assertStringContainsString('Parse Error', $this->getLastErrorMessage());
-        $this->assertStringContainsString('at line 4', $this->getLastErrorMessage());
         $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
+        $this->assertStringContainsStringIgnoringCase('STOP tag not matching START', $this->getLastErrorMessage());
+        $this->assertStringContainsString('at line 4', $this->getLastErrorMessage());
+    }
+
+    public function testUnclosedParseError(): void
+    {
+        $code = <<<'CODE'
+1 # TRAINING EXERCISE START STEP 1
+2 # TRAINING EXERCISE START STEP 2
+3 Whatever
+4 # TRAINING EXERCISE STOP STEP 2
+CODE;
+        $codeLines = explode(PHP_EOL, $code);
+
+        $this->exerciseCleaner->cleanCodeLines($codeLines);
+
+        $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
+        $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->getLastErrorMessage());
+        $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
+
+        $this->resetErrors();
+
+        $code = <<<'CODE'
+1 # TRAINING EXERCISE START STEP 1
+2 # TRAINING EXERCISE START STEP 2
+3 # TRAINING EXERCISE START STEP 3
+4 # TRAINING EXERCISE STOP STEP 3
+CODE;
+        $codeLines = explode(PHP_EOL, $code);
+
+        $this->exerciseCleaner->cleanCodeLines($codeLines);
+
+        $this->assertCount(2, $this->errors);
+
+        $this->assertEquals(E_USER_ERROR, $this->errors[0]['type']);
+        $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->errors[0]['message']);
+        $this->assertStringContainsString('at line 2', $this->errors[0]['message']);
+
+        $this->assertEquals(E_USER_ERROR, $this->errors[1]['type']);
+        $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->errors[1]['message']);
+        $this->assertStringContainsString('at line 1', $this->errors[1]['message']);
+    }
+
+    public function testTagParseError(): void
+    {
+        foreach ([
+                     'TRAINING EXERCISE STEP 1 START',
+                     'TRAINING EXERCISE STEP START 1',
+                     'TRAINING EXERCISE START 1',
+                     '',
+                     ] as $tag) {
+            $this->exerciseCleaner->cleanCodeLines([$tag]);
+            $this->assertStringContainsStringIgnoringCase('tag parse error', $this->getLastErrorMessage());
+            $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
+        }
     }
 
     public function testThresholdWarning(): void
@@ -576,9 +678,9 @@ CODE;
 
         $this->exerciseCleaner->cleanCodeLines($codeLines);
 
+        $this->assertEquals(E_USER_WARNING, $this->getLastErrorType());
         $this->assertStringContainsString('Threshold less or equals to step', $this->getLastErrorMessage());
         $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
-        $this->assertEquals(E_USER_WARNING, $this->getLastErrorType());
     }
 
     public function testUnsupportedCommentWarning(): void
@@ -595,27 +697,64 @@ CODE;
 
         $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.json');
 
-        $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[0]['string']);
-        $this->assertStringContainsString('at line 1', $this->errors[0]['string']);
-        $this->assertEquals(E_USER_WARNING, $this->errors[0]['number']);
+        $this->assertEquals(E_USER_WARNING, $this->errors[0]['type']);
+        $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[0]['message']);
+        $this->assertStringContainsString('at line 1', $this->errors[0]['message']);
 
-        $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[1]['string']);
-        $this->assertStringContainsString('at line 4', $this->errors[1]['string']);
-        $this->assertEquals(E_USER_WARNING, $this->errors[1]['number']);
+        $this->assertEquals(E_USER_WARNING, $this->errors[1]['type']);
+        $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[1]['message']);
+        $this->assertStringContainsString('at line 4', $this->errors[1]['message']);
     }
+
+    public function testPlaceholderOutsideError(): void
+    {
+        $code = <<<'CODE'
+1 # TRAINING EXERCISE START STEP 2
+2 Whatever
+3 # TRAINING EXERCISE STOP STEP 2
+4 # TRAINING EXERCISE STEP PLACEHOLDER instruction
+CODE;
+        $codeLines = explode(PHP_EOL, $code);
+
+        for ($step = 1; $step < 4; ++$step) {
+            $this->exerciseCleaner->cleanCodeLines($codeLines, $step);
+            $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
+            $this->assertStringContainsString("can't be used outside", $this->getLastErrorMessage());
+            $this->assertStringContainsString('at line 4', $this->getLastErrorMessage());
+        }
+    }
+
+    public function testPlaceholderUnnecessaryNotice(): void
+    {
+        $code = <<<'CODE'
+1 # TRAINING EXERCISE START STEP 1 PLACEHOLDER
+2 TRAINING EXERCISE STEP PLACEHOLDER Instruction:
+3 Instruction
+4 # TRAINING EXERCISE STOP STEP 1
+CODE;
+        $codeLines = explode(PHP_EOL, $code);
+
+        $this->exerciseCleaner->cleanCodeLines($codeLines, 1);
+        $this->assertEquals(E_USER_NOTICE, $this->getLastErrorType());
+        $this->assertStringContainsStringIgnoringCase('unnecessary', $this->getLastErrorMessage());
+        $this->assertStringContainsString('at line 2', $this->getLastErrorMessage());
+    }
+
+    /********************/
+    /* Error Test Tools */
 
     /** @var array[] */
     private $errors = [];
 
-    public function errorHandler($number, $string): void
+    public function errorHandler($type, $message): void
     {
-        $this->errors[] = compact('number', 'string');
+        $this->errors[] = compact('type', 'message');
     }
 
     private function getLastErrorMessage(): ?string
     {
         if (count($this->errors)) {
-            return $this->errors[count($this->errors) - 1]['string'];
+            return $this->errors[count($this->errors) - 1]['message'];
         }
 
         return null;
@@ -624,7 +763,7 @@ CODE;
     private function getLastErrorType(): ?int
     {
         if (count($this->errors)) {
-            return $this->errors[count($this->errors) - 1]['number'];
+            return $this->errors[count($this->errors) - 1]['type'];
         }
 
         return null;

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -187,8 +187,8 @@ class ExerciseCleanerTest extends TestCase
     /** Do not parse, simply remove non alpha-numeric characters */
     private function cleanTag(string $tag): string
     {
-        $tag = preg_replace('/^[^A-Z0-9\.]*/', '', $tag);
-        $tag = preg_replace('/[^A-Z0-9\.]*$/', '', $tag);
+        $tag = preg_replace('/^[^A-Z0-9.]*/', '', $tag);
+        $tag = preg_replace('/[^A-Z0-9.]*$/', '', $tag);
 
         return trim($tag);
     }
@@ -196,7 +196,7 @@ class ExerciseCleanerTest extends TestCase
     /***********************/
     /* Code Cleaning Tests */
 
-    public function testSimplestTag()
+    public function testSimplestTag(): void
     {
         $code = <<<'CODE'
 TRAINING EXERCISE START STEP 2
@@ -233,7 +233,7 @@ CODE;
         $this->assertEquals('test', $cleanedCodeLines[0]);
     }
 
-    public function testSimplestTagWithFloats()
+    public function testSimplestTagWithFloats(): void
     {
         $code = <<<'CODE'
 TRAINING EXERCISE START STEP 1.0

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -611,7 +611,7 @@ CODE;
 
         $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
         $this->assertStringContainsStringIgnoringCase('STOP tag not matching START', $this->getLastErrorMessage());
-        $this->assertStringContainsString('at line 4', $this->getLastErrorMessage());
+        $this->assertStringContainsString('on line 4', $this->getLastErrorMessage());
     }
 
     public function testUnclosedParseError(): void
@@ -628,7 +628,7 @@ CODE;
 
         $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
         $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->getLastErrorMessage());
-        $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
+        $this->assertStringContainsString('on line 1', $this->getLastErrorMessage());
 
         $this->resetErrors();
 
@@ -646,11 +646,11 @@ CODE;
 
         $this->assertEquals(E_USER_ERROR, $this->errors[0]['type']);
         $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->errors[0]['message']);
-        $this->assertStringContainsString('at line 2', $this->errors[0]['message']);
+        $this->assertStringContainsString('on line 2', $this->errors[0]['message']);
 
         $this->assertEquals(E_USER_ERROR, $this->errors[1]['type']);
         $this->assertStringContainsStringIgnoringCase('unclosed tag', $this->errors[1]['message']);
-        $this->assertStringContainsString('at line 1', $this->errors[1]['message']);
+        $this->assertStringContainsString('on line 1', $this->errors[1]['message']);
     }
 
     public function testTagParseError(): void
@@ -663,7 +663,7 @@ CODE;
                      ] as $tag) {
             $this->exerciseCleaner->cleanCodeLines([$tag]);
             $this->assertStringContainsStringIgnoringCase('tag parse error', $this->getLastErrorMessage());
-            $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
+            $this->assertStringContainsString('on line 1', $this->getLastErrorMessage());
         }
     }
 
@@ -680,7 +680,7 @@ CODE;
 
         $this->assertEquals(E_USER_WARNING, $this->getLastErrorType());
         $this->assertStringContainsString('Threshold less or equals to step', $this->getLastErrorMessage());
-        $this->assertStringContainsString('at line 1', $this->getLastErrorMessage());
+        $this->assertStringContainsString('on line 1', $this->getLastErrorMessage());
     }
 
     public function testUnsupportedCommentWarning(): void
@@ -699,11 +699,11 @@ CODE;
 
         $this->assertEquals(E_USER_WARNING, $this->errors[0]['type']);
         $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[0]['message']);
-        $this->assertStringContainsString('at line 1', $this->errors[0]['message']);
+        $this->assertStringContainsString('on line 1', $this->errors[0]['message']);
 
         $this->assertEquals(E_USER_WARNING, $this->errors[1]['type']);
         $this->assertStringContainsString('Unsupported COMMENT action', $this->errors[1]['message']);
-        $this->assertStringContainsString('at line 4', $this->errors[1]['message']);
+        $this->assertStringContainsString('on line 4', $this->errors[1]['message']);
     }
 
     public function testPlaceholderOutsideError(): void
@@ -720,7 +720,7 @@ CODE;
             $this->exerciseCleaner->cleanCodeLines($codeLines, $step);
             $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
             $this->assertStringContainsString("can't be used outside", $this->getLastErrorMessage());
-            $this->assertStringContainsString('at line 4', $this->getLastErrorMessage());
+            $this->assertStringContainsString('on line 4', $this->getLastErrorMessage());
         }
     }
 
@@ -737,7 +737,7 @@ CODE;
         $this->exerciseCleaner->cleanCodeLines($codeLines, 1);
         $this->assertEquals(E_USER_NOTICE, $this->getLastErrorType());
         $this->assertStringContainsStringIgnoringCase('unnecessary', $this->getLastErrorMessage());
-        $this->assertStringContainsString('at line 2', $this->getLastErrorMessage());
+        $this->assertStringContainsString('on line 2', $this->getLastErrorMessage());
     }
 
     /********************/

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -434,6 +434,8 @@ CODE;
 
         $this->assertEquals(['Step 1 Introduction', 'Steps 1 & 2 Introduction'], $this->exerciseCleaner->cleanCodeLines($codeLines, 1, false));
         $this->assertEquals(['Step 1 Introduction', 'Steps 1 & 2 Introduction', 'Step 1 Solution'], $this->exerciseCleaner->cleanCodeLines($codeLines, 1, true));
+        $this->assertStringContainsString('INTRO keyword is deprecated', $this->getLastErrorString());
+        $this->assertEquals(E_USER_DEPRECATED, $this->getLastErrorNumber());
 
         $this->assertEquals(['Steps 1 & 2 Introduction', 'Step 2+ Introduction'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.php'));
         $this->assertEquals(['Steps 1 & 2 Introduction', 'Step 2+ Introduction', 'Step 2+ Solution'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.php'));

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -607,11 +607,11 @@ CODE;
 CODE;
         $codeLines = explode(PHP_EOL, $code);
 
-        $this->exerciseCleaner->cleanCodeLines($codeLines);
+        $this->exerciseCleaner->cleanCodeLines($codeLines, 1, false, false, './fake_file_name.php');
 
         $this->assertEquals(E_USER_ERROR, $this->getLastErrorType());
         $this->assertStringContainsStringIgnoringCase('STOP tag not matching START', $this->getLastErrorMessage());
-        $this->assertStringContainsString('on line 4', $this->getLastErrorMessage());
+        $this->assertStringContainsString('in ./fake_file_name.php on line 4', $this->getLastErrorMessage());
     }
 
     public function testUnclosedParseError(): void

--- a/tests/ExerciseCleanerTest.php
+++ b/tests/ExerciseCleanerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 use ExerciseCleaner\ExerciseCleaner;
 use PHPUnit\Framework\TestCase;
@@ -375,13 +375,24 @@ CODE;
         $this->assertEquals(['  // Step 1'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.php'));
         $this->assertEquals(['  // Step 1', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.php'));
 
-        // Sharp Style
+        // INI Style
+        $this->assertEquals(['  ; Step 1'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.ini'));
+        $this->assertEquals(['  ; Step 1', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.ini'));
+
+        // Number Sign Style
         $this->assertEquals(['  # Step 1'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.sh'));
         $this->assertEquals(['  # Step 1', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.yaml'));
+        // …As default
+        $this->assertEquals(['  # Step 1'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false));
+        $this->assertEquals(['  # Step 1', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, null));
 
         // Twig Style
         $this->assertEquals(['  {# Step 1 #}'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.twig'));
         $this->assertEquals(['  {# Step 1 #}', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.twig'));
+
+        // XML Style
+        $this->assertEquals(['  <!-- Step 1 -->'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.xml'));
+        $this->assertEquals(['  <!-- Step 1 -->', '  Step 2+'], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, true, false, '.xml'));
 
         // Unsupported
         $this->assertEquals([], $this->exerciseCleaner->cleanCodeLines($codeLines, 2, false, false, '.json'));
@@ -601,7 +612,7 @@ CODE;
         $this->errors[] = compact('number', 'string');
     }
 
-    private function getLastErrorMessage(): string
+    private function getLastErrorMessage(): ?string
     {
         if (count($this->errors)) {
             return $this->errors[count($this->errors) - 1]['string'];
@@ -610,7 +621,7 @@ CODE;
         return null;
     }
 
-    private function getLastErrorType(): int
+    private function getLastErrorType(): ?int
     {
         if (count($this->errors)) {
             return $this->errors[count($this->errors) - 1]['number'];


### PR DESCRIPTION
**Clearer Grammar**
- Approximative Old Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [INTRO] [<action> [UNTIL <step_number> [THEN <action>]] [INTRO]`
- Defined New Syntax: `TRAINING EXERCISE <boundary> STEP <step_number> [<state>] [<action>] [UNTIL <step_number> [THEN <action>]]`

**New Features**
- Introduce `<state>` at a fixed place instead of volatil (and now deprecated) `INTRO`.
- Introduce `PLACEHOLDER` state, replace `INTRO` with `WORKSHEET` state.
- INI and XML handled by `COMMENT` action
- Show unclosed tag error

**Developpement Flow**
- Add [Symfony's Coding Standards](https://symfony.com/doc/current/contributing/code/standards.html) validation to [GitHub Actions](https://github.com/features/actions)

 